### PR TITLE
Add weekly AD extension update scripts

### DIFF
--- a/Examples/Register-UpdateADUserExtensionTask.ps1
+++ b/Examples/Register-UpdateADUserExtensionTask.ps1
@@ -1,0 +1,10 @@
+#requires -Modules ScheduledTasks
+
+$ScriptPath = Join-Path $PSScriptRoot 'Update-ADUserExtensionAttributes.ps1'
+$Action = New-ScheduledTaskAction -Execute 'PowerShell.exe' -Argument "-NoProfile -WindowStyle Hidden -File `"$ScriptPath`""
+$Trigger = New-ScheduledTaskTrigger -Weekly -DaysOfWeek Sunday -At 2am
+$Principal = New-ScheduledTaskPrincipal -UserId 'SYSTEM' -LogonType ServiceAccount -RunLevel Highest
+$TaskName = 'Update-ADUserExtensionAttributes'
+
+Register-ScheduledTask -TaskName $TaskName -Action $Action -Trigger $Trigger -Principal $Principal -Force
+

--- a/Examples/Update-ADUserExtensionAttributes.ps1
+++ b/Examples/Update-ADUserExtensionAttributes.ps1
@@ -1,0 +1,27 @@
+#requires -Modules ActiveDirectory
+
+<#!
+.SYNOPSIS
+    Sets extension attributes for newly created Active Directory users.
+.DESCRIPTION
+    Searches Active Directory for user accounts created within the last week.
+    If a user's employeeID begins with "10" the script sets values on
+    extensionAttribute1, extensionAttribute2 and extensionAttribute3.
+!>
+
+$LastWeek = (Get-Date).AddDays(-7)
+
+# Extension attribute values to apply
+$attributes = @{
+    extensionAttribute1 = 'Value1'
+    extensionAttribute2 = 'Value2'
+    extensionAttribute3 = 'Value3'
+}
+
+$NewUsers = Get-ADUser -Filter * -Properties whenCreated, employeeID | Where-Object {
+    $_.whenCreated -ge $LastWeek -and $_.employeeID -like '10*'
+}
+
+foreach ($user in $NewUsers) {
+    Set-ADUser -Identity $user -Replace $attributes
+}


### PR DESCRIPTION
## Summary
- add script that updates extension attributes for newly created AD users
- add script to register a weekly scheduled task for the update

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6877dfe0205c832aae8fe60a19dad739